### PR TITLE
Pipe backend headers and status to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ typings/
 .env
 dist/
 .DS_Store
+.idea/

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -128,11 +128,16 @@ describe('Backend Proxy', () => {
 
 			const backendResponse = new EventEmitter();
 			backendResponse.headers = {
-				'content-type': 'not-the-right-one'
+				'content-type': 'not-the-right-one',
+				'dummy-header': 'dummy-value'
 			};
+			backendResponse.statusCode = 302;
 			backendResponse.pipe = jest.fn();
 
-			const response = {field2: 'value2'};
+			const response = {
+				header: jest.fn()
+			};
+
 			middleware(mockRequest, response, next);
 
 			// When
@@ -141,6 +146,8 @@ describe('Backend Proxy', () => {
 			// Then
 			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
 			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+			expect(response.header).toHaveBeenCalledWith(backendResponse.headers);
+			expect(response.statusCode).toBe(backendResponse.statusCode);
 			expect(next).not.toHaveBeenCalled();
 		});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2462,7 +2462,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2483,12 +2484,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2503,17 +2506,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2630,7 +2636,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2642,6 +2649,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2656,6 +2664,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2663,12 +2672,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2687,6 +2698,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2767,7 +2779,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2779,6 +2792,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2864,7 +2878,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2900,6 +2915,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2919,6 +2935,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2962,12 +2979,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -70,6 +70,8 @@ function backendProxy(options) {
 				});
 			} else {
 				// Pipe it back to the client as is
+				response.statusCode = backendResponse.statusCode;
+				response.header(backendResponse.headers);
 				backendResponse.pipe(response);
 			}
 		});


### PR DESCRIPTION
The `request` library that was previously used took care of piping headers and status code. The node `http` library simply exposes a `stream` which has fields for those. So they don't get piped to the client.