### PR TITLE
Removes backend domain from location on a 30x response

### DIFF
--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -91,6 +91,20 @@ describe('Backend proxy integration', () => {
 			});
 	});
 
+	test('proxies a request to redirect', () => {
+		const location = 'http://not.the-back.end/my-nice/location?here=there#my-id';
+		const scope = nock(backend).get('/hello/world')
+			.reply(301, {}, {location});
+
+		return request.get('/usePathOn/hello/world')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(301);
+				expect(response.headers.location).toEqual(location);
+			});
+	});
+
 	test('proxies a request to redirect and removes backend from the header', () => {
 		const relativePath = `/my-nice/location?here=there#my-id`;
 		const scope = nock(backend).get('/hello/world')
@@ -102,20 +116,6 @@ describe('Backend proxy integration', () => {
 
 				expect(response.status).toBe(301);
 				expect(response.headers.location).toEqual(relativePath);
-			});
-	});
-
-	test('proxies a request to redirect', () => {
-		const location = 'http://not.the-back.end/my-nice/location?here=there#my-id';
-		const scope = nock(backend).get('/hello/world')
-			.reply(301, {}, {location: `${location}`});
-
-		return request.get('/usePathOn/hello/world')
-			.then(response => {
-				scope.done();
-
-				expect(response.status).toBe(301);
-				expect(response.headers.location).toEqual(location);
 			});
 	});
 });

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -100,7 +100,7 @@ describe('Backend proxy integration', () => {
 			.then(response => {
 				scope.done();
 
-				expect(response.status).toBe(301);
+				expect(response.status).toBe(307);
 				expect(response.headers.location).toEqual(location);
 			});
 	});

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -94,7 +94,7 @@ describe('Backend proxy integration', () => {
 	test('proxies a request to redirect', () => {
 		const location = 'http://not.the-back.end/my-nice/location?here=there#my-id';
 		const scope = nock(backend).get('/hello/world')
-			.reply(301, {}, {location});
+			.reply(307, {}, {location});
 
 		return request.get('/usePathOn/hello/world')
 			.then(response => {

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -90,5 +90,19 @@ describe('Backend proxy integration', () => {
 				expect(response.body).toEqual(backendData);
 			});
 	});
+
+	test('proxies a request to redirect and removes backend from the header', () => {
+		const relativePath = `/my-nice/location?here=there#my-id`;
+		const scope = nock(backend).get('/hello/world')
+			.reply(301, {}, {location: `${backend}${relativePath}`});
+
+		return request.get('/usePathOn/hello/world')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(301);
+				expect(response.headers.location).toEqual(relativePath);
+			});
+	});
 });
 

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -104,5 +104,19 @@ describe('Backend proxy integration', () => {
 				expect(response.headers.location).toEqual(relativePath);
 			});
 	});
+
+	test('proxies a request to redirect', () => {
+		const location = 'http://not.the-back.end/my-nice/location?here=there#my-id';
+		const scope = nock(backend).get('/hello/world')
+			.reply(301, {}, {location: `${location}`});
+
+		return request.get('/usePathOn/hello/world')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(301);
+				expect(response.headers.location).toEqual(location);
+			});
+	});
 });
 

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -287,7 +287,7 @@ describe('Backend Proxy', () => {
 			// Given
 			const middleware = backendProxy(baseOptions);
 
-			let relativeLocation = `/some-wonderful/location`;
+			let relativeLocation = `/some-wonderful/location?here=there#my-id`;
 
 			const backendResponse = new EventEmitter();
 			backendResponse.headers = {

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -83,7 +83,7 @@ function backendProxy(options) {
 				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 &&
 					backendResponse.headers.location &&
 					backendResponse.headers.location.startsWith(options.backend)) {
-					let url = new URL(backendResponse.headers.location);
+					let url = new url.URL(backendResponse.headers.location);
 					backendResponse.headers.location = url.pathname + url.search + url.hash;
 				}
 

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -79,6 +79,14 @@ function backendProxy(options) {
 			} else {
 				// Pipe it back to the client as is
 				response.statusCode = backendResponse.statusCode;
+
+				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 &&
+					backendResponse.headers.location &&
+					backendResponse.headers.location.startsWith(options.backend)) {
+					let url = new URL(backendResponse.headers.location);
+					backendResponse.headers.location = url.pathname + url.search + url.hash;
+				}
+
 				response.header(backendResponse.headers);
 				backendResponse.pipe(response);
 			}

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -83,8 +83,8 @@ function backendProxy(options) {
 				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 &&
 					backendResponse.headers.location &&
 					backendResponse.headers.location.startsWith(options.backend)) {
-					let url = new URL(backendResponse.headers.location);
-					backendResponse.headers.location = url.pathname + url.search + url.hash;
+					let locationUrl = new url.URL(backendResponse.headers.location);
+					backendResponse.headers.location = locationUrl.pathname + locationUrl.search + locationUrl.hash;
 				}
 
 				response.header(backendResponse.headers);


### PR DESCRIPTION
[Issue 19](https://github.com/springernature/backend-proxy/issues/19) describes a bug where a backend sends a 30x redirect, the location is forced to be an absolute URL and that defaults to the backend's domain. This is present when communicating with a .NET server, where if there is no domain in the location it is set to the server's address. 

This problem is resolved by converting the location from an absolute URL to a relative one. The conditions for this transformation are that the response code is a 30x and the location starts with the address of the backend server.