### PR TITLE
Specifies the host header in the correct order. 

### DIFF
--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -114,7 +114,9 @@ describe('Backend Proxy', () => {
 			backend: 'http://backend.local/sub/path',
 			changeHost: true
 		});
-		mockRequest.hostname = 'original.host:8080';
+		mockRequest.headers = {
+			host: 'original.host:8080'
+		};
 
 		// When
 		middleware(mockRequest, undefined, next);
@@ -127,7 +129,7 @@ describe('Backend Proxy', () => {
 			headers: {
 				...mockRequest.headers,
 				host: 'backend.local',
-				'X-Orig-Host': mockRequest.hostname
+				'X-Orig-Host': 'original.host:8080'
 			}
 		}));
 		// We haven't simulated an error or a response so next should not have been called at this point

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pretest": "npm run lint",
     "lint": "eslint src __tests__",
     "test": "jest --coverage",
-    "test:watch": "jest --watch --testPathIgnorePatterns integration"
+    "test:watch": "jest --watch"
   },
   "engines": {
     "node": ">= 8.3.0"

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -53,8 +53,8 @@ function backendProxy(options) {
 		};
 
 		if (options.changeHost) {
+			request.headers['X-Orig-Host'] = request.headers.host;
 			request.headers.host = backendHttpOptions.host;
-			request.headers['X-Orig-Host'] = request.hostname;
 		}
 
 		// Pipe the incoming request through to the backend


### PR DESCRIPTION
Fixes #18 

Express appears to link the `request.host` and the `request.headers.host` field, which causes updating one to update the other.