### PR TITLE
Check if redirect location contains backend

### DIFF
--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -99,7 +99,6 @@ describe('Backend proxy integration', () => {
 			});
 	});
 
-
 	test('proxies a request with a changed host if the domain matches the backend domain, but not the backend path', () => {
 		const relativePath = `/my-nice/location?here=there#my-id`;
 		const scope = nock(backend).get('/hello/world')

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -99,6 +99,21 @@ describe('Backend proxy integration', () => {
 			});
 	});
 
+
+	test('proxies a request with a changed host if the domain matches the backend domain, but not the backend path', () => {
+		const relativePath = `/my-nice/location?here=there#my-id`;
+		const scope = nock(backend).get('/hello/world')
+			.reply(302, {}, {location: `${backend}/an-extra/path/${relativePath}`});
+
+		return request.get('/usePathOn/hello/world')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(302);
+				expect(response.headers.location).toEqual(`/an-extra/path/${relativePath}`);
+			});
+	});
+
 	test('proxies a request to redirect', () => {
 		const location = 'http://not.the-back.end/my-nice/location?here=there#my-id';
 		const scope = nock(backend).get('/hello/world')

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -381,7 +381,6 @@ describe('Backend Proxy', () => {
 				backendResponse.headers = {
 					location: baseOptions.backend + relativeLocation
 				};
-				backendResponse.statusCode = 302;
 
 				middleware(mockRequest, response, next);
 

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -285,165 +285,139 @@ describe('Backend Proxy', () => {
 			}));
 		});
 
-		test('forwards a 399 backend response with a rewritten location if the location header is to the backend server', () => {
-			// Given
-			const middleware = backendProxy(baseOptions);
-			let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+		describe('redirect', () => {
+			let middleware;
+			let backendResponse;
+			let response;
 
-			const backendResponse = new EventEmitter();
-			backendResponse.headers = {
-				location: baseOptions.backend + relativeLocation
-			};
+			beforeEach(() => {
+				middleware = backendProxy(baseOptions);
 
-			backendResponse.statusCode = 399;
-			backendResponse.pipe = jest.fn();
+				backendResponse = new EventEmitter();
+				backendResponse.statusCode = 300;
+				backendResponse.pipe = jest.fn();
 
-			const response = {
-				header: jest.fn()
-			};
-
-			middleware(mockRequest, response, next);
-
-			// When
-			proxyRequest.emit('response', backendResponse);
-
-			// Then
-			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
-			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
-			expect(response.header).toHaveBeenCalledWith({
-				...backendResponse.headers,
-				location: relativeLocation
+				response = {
+					header: jest.fn()
+				};
 			});
-			expect(response.statusCode).toBe(backendResponse.statusCode);
-			expect(next).not.toHaveBeenCalled();
-		});
 
-		test('forwards a 300 backend response with a rewritten location if the location header is to the backend server', () => {
-			// Given
-			const middleware = backendProxy(baseOptions);
-			let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+			test('forwards a 399 backend response with a rewritten location if the location header is to the backend server', () => {
+				// Given
+				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
 
-			const backendResponse = new EventEmitter();
-			backendResponse.headers = {
-				location: baseOptions.backend + relativeLocation
-			};
+				backendResponse.headers = {
+					location: baseOptions.backend + relativeLocation
+				};
+				backendResponse.statusCode = 399;
 
-			backendResponse.statusCode = 300;
-			backendResponse.pipe = jest.fn();
+				middleware(mockRequest, response, next);
 
-			const response = {
-				header: jest.fn()
-			};
+				// When
+				proxyRequest.emit('response', backendResponse);
 
-			middleware(mockRequest, response, next);
-
-			// When
-			proxyRequest.emit('response', backendResponse);
-
-			// Then
-			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
-			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
-			expect(response.header).toHaveBeenCalledWith({
-				...backendResponse.headers,
-				location: relativeLocation
+				// Then
+				expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
+				expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+				expect(response.header).toHaveBeenCalledWith({
+					...backendResponse.headers,
+					location: relativeLocation
+				});
+				expect(response.statusCode).toBe(backendResponse.statusCode);
+				expect(next).not.toHaveBeenCalled();
 			});
-			expect(response.statusCode).toBe(backendResponse.statusCode);
-			expect(next).not.toHaveBeenCalled();
-		});
 
-		test(`forwards a 30x backend response without change if there is no location header`, () => {
-			// Given
-			const middleware = backendProxy(baseOptions);
+			test('forwards a 300 backend response with a rewritten location if the location header is to the backend server', () => {
+				// Given
+				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+				backendResponse.headers = {
+					location: baseOptions.backend + relativeLocation
+				};
 
-			const backendResponse = new EventEmitter();
-			backendResponse.headers = {
-				'content-type': 'text/plain'
-			};
+				middleware(mockRequest, response, next);
 
-			backendResponse.statusCode = 302;
-			backendResponse.pipe = jest.fn();
+				// When
+				proxyRequest.emit('response', backendResponse);
 
-			const response = {
-				header: jest.fn()
-			};
-
-			middleware(mockRequest, response, next);
-
-			// When
-			proxyRequest.emit('response', backendResponse);
-
-			// Then
-			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
-			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
-			expect(response.header).toHaveBeenCalledWith(backendResponse.headers);
-			expect(response.statusCode).toBe(backendResponse.statusCode);
-			expect(next).not.toHaveBeenCalled();
-		});
-
-		test('rewrites the location header if the domain matches the backend domain, but not the backend path', () => {
-			// Given
-			const middleware = backendProxy({
-				...baseOptions,
-				backend: baseOptions.backend + '/additional/path'
+				// Then
+				expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
+				expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+				expect(response.header).toHaveBeenCalledWith({
+					...backendResponse.headers,
+					location: relativeLocation
+				});
+				expect(response.statusCode).toBe(backendResponse.statusCode);
+				expect(next).not.toHaveBeenCalled();
 			});
-			let relativeLocation = `/some-wonderful/location?here=there#my-id`;
 
-			const backendResponse = new EventEmitter();
-			backendResponse.headers = {
-				location: baseOptions.backend + relativeLocation
-			};
+			test(`forwards a 30x backend response without change if there is no location header`, () => {
+				// Given
+				backendResponse.headers = {
+					'content-type': 'text/plain'
+				};
+				backendResponse.statusCode = 302;
 
-			backendResponse.statusCode = 302;
-			backendResponse.pipe = jest.fn();
+				middleware(mockRequest, response, next);
 
-			const response = {
-				header: jest.fn()
-			};
+				// When
+				proxyRequest.emit('response', backendResponse);
 
-			middleware(mockRequest, response, next);
-
-			// When
-			proxyRequest.emit('response', backendResponse);
-
-			// Then
-			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
-			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
-			expect(response.header).toHaveBeenCalledWith({
-				...backendResponse.headers,
-				location: relativeLocation
+				// Then
+				expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
+				expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+				expect(response.header).toHaveBeenCalledWith(backendResponse.headers);
+				expect(response.statusCode).toBe(backendResponse.statusCode);
+				expect(next).not.toHaveBeenCalled();
 			});
-			expect(response.statusCode).toBe(backendResponse.statusCode);
-			expect(next).not.toHaveBeenCalled();
-		});
 
-		test(`forwards a 30x redirect with no changes to the location header`, () => {
-			// Given
-			const middleware = backendProxy(baseOptions);
-			let location = `http://not.the-back.end/some-wonderful/location?here=there#my-id`;
+			test('rewrites the location header if the domain matches the backend domain, but not the backend path', () => {
+				// Given
+				middleware = backendProxy({
+					...baseOptions,
+					backend: baseOptions.backend + '/additional/path'
+				});
 
-			const backendResponse = new EventEmitter();
-			backendResponse.headers = {
-				location
-			};
+				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+				backendResponse.headers = {
+					location: baseOptions.backend + relativeLocation
+				};
+				backendResponse.statusCode = 302;
 
-			backendResponse.statusCode = 302;
-			backendResponse.pipe = jest.fn();
+				middleware(mockRequest, response, next);
 
-			const response = {
-				header: jest.fn()
-			};
+				// When
+				proxyRequest.emit('response', backendResponse);
 
-			middleware(mockRequest, response, next);
+				// Then
+				expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
+				expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+				expect(response.header).toHaveBeenCalledWith({
+					...backendResponse.headers,
+					location: relativeLocation
+				});
+				expect(response.statusCode).toBe(backendResponse.statusCode);
+				expect(next).not.toHaveBeenCalled();
+			});
 
-			// When
-			proxyRequest.emit('response', backendResponse);
+			test(`forwards a 30x redirect with no changes to the location header`, () => {
+				// Given
+				backendResponse.headers = {
+					location: 'http://not.the-back.end/some-wonderful/location?here=there#my-id'
+				};
+				backendResponse.statusCode = 302;
 
-			// Then
-			expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
-			expect(backendResponse.pipe).toHaveBeenCalledWith(response);
-			expect(response.header).toHaveBeenCalledWith(backendResponse.headers);
-			expect(response.statusCode).toBe(backendResponse.statusCode);
-			expect(next).not.toHaveBeenCalled();
+				middleware(mockRequest, response, next);
+
+				// When
+				proxyRequest.emit('response', backendResponse);
+
+				// Then
+				expect(backendResponse.pipe).toHaveBeenCalledTimes(1);
+				expect(backendResponse.pipe).toHaveBeenCalledWith(response);
+				expect(response.header).toHaveBeenCalledWith(backendResponse.headers);
+				expect(response.statusCode).toBe(backendResponse.statusCode);
+				expect(next).not.toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -304,7 +304,7 @@ describe('Backend Proxy', () => {
 
 			test('forwards a 399 backend response with a rewritten location if the location header is to the backend server', () => {
 				// Given
-				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+				const relativeLocation = `/some-wonderful/location?here=there#my-id`;
 
 				backendResponse.headers = {
 					location: baseOptions.backend + relativeLocation
@@ -329,7 +329,7 @@ describe('Backend Proxy', () => {
 
 			test('forwards a 300 backend response with a rewritten location if the location header is to the backend server', () => {
 				// Given
-				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+				const relativeLocation = `/some-wonderful/location?here=there#my-id`;
 				backendResponse.headers = {
 					location: baseOptions.backend + relativeLocation
 				};
@@ -377,7 +377,7 @@ describe('Backend Proxy', () => {
 					backend: baseOptions.backend + '/additional/path'
 				});
 
-				let relativeLocation = `/some-wonderful/location?here=there#my-id`;
+				const relativeLocation = `/some-wonderful/location?here=there#my-id`;
 				backendResponse.headers = {
 					location: baseOptions.backend + relativeLocation
 				};

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -81,7 +81,7 @@ function backendProxy(options) {
 				response.statusCode = backendResponse.statusCode;
 
 				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 && backendResponse.headers.location) {
-					if (backendResponse.headers.location.indexOf(backendHttpOptions.host) !== -1) {
+					if (backendResponse.headers.location.includes(backendHttpOptions.host)) {
 						const locationUrl = new url.URL(backendResponse.headers.location);
 						backendResponse.headers.location = locationUrl.pathname + locationUrl.search + locationUrl.hash;
 					}

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -80,11 +80,11 @@ function backendProxy(options) {
 				// Pipe it back to the client as is
 				response.statusCode = backendResponse.statusCode;
 
-				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 &&
-					backendResponse.headers.location &&
-					backendResponse.headers.location.startsWith(options.backend)) {
-					let locationUrl = new url.URL(backendResponse.headers.location);
-					backendResponse.headers.location = locationUrl.pathname + locationUrl.search + locationUrl.hash;
+				if (backendResponse.statusCode >= 300 && backendResponse.statusCode <= 399 && backendResponse.headers.location) {
+					if (backendResponse.headers.location.indexOf(backendHttpOptions.host) !== -1) {
+						const locationUrl = new url.URL(backendResponse.headers.location);
+						backendResponse.headers.location = locationUrl.pathname + locationUrl.search + locationUrl.hash;
+					}
 				}
 
 				response.header(backendResponse.headers);


### PR DESCRIPTION
Fixes #22. 

This changes the location rewrite to check to see if the location contains the host of the backend, rather than checking it starts with the entire backend URL. 