### PR TITLE
Error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ app.use('/login', backendProxy({
 The following table describe the properties of the `options` object.
 
 | *Property* | *Description* | *Type* | *Default* |
-|-----------------------|----------------------------------------------------------------------------------------|---------|--------------------|
+|---|---|---|---|
 | `backend` | Backend service to proxy requests to | string |  |
 | `requiredContentType` | Backend response content type thats required to allow interception and deserialization | string | `application/json` |
 | `usePath` | Should the incoming HTTP request's path be apended to the `backend` URL | boolean | `true` |
 | `changeHost` | Set the `host` header on the backend HTTP request to the backend host | boolean | `false` |
+| `interceptErrors` | Should backend responses with HTTP 400 - 599 be intercepted and raised as express errors. | boolean | `false` |
 | `key` | The property on the request object that the backend response will be stored under. | string | `backendResponse` |
 
 ### `renderBackendResponse(options)`

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -43,7 +43,7 @@ app.use('*', (request, response) => {
 });
 
 app.use((error, request, response, _) => {
-	response.json(error);
+	response.send(`Error ${error.statusCode}`);
 });
 
 describe('Backend proxy integration', () => {
@@ -159,8 +159,8 @@ describe('Backend proxy integration', () => {
 			.then(response => {
 				scope.done();
 
-				expect(response.status).toBe(200);
-				expect(response.body).toEqual({statusCode: 401});
+				expect(response.status).toBe(401);
+				expect(response.text).toEqual(`Error 401`);
 			});
 	});
 });

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -30,10 +30,20 @@ app.use('/changeHostOn', backendProxy({
 	changeHost: true
 }));
 
+app.get('/interceptOn', backendProxy({
+	backend,
+	requiredContentType: 'application/x+json',
+	interceptErrors: true
+}));
+
 // Always return the backendResponse field as json
 app.use('*', (request, response) => {
 	response.json(request.backendResponse);
 	response.end();
+});
+
+app.use((error, request, response, _) => {
+	response.json(error);
 });
 
 describe('Backend proxy integration', () => {
@@ -138,6 +148,19 @@ describe('Backend proxy integration', () => {
 
 				expect(response.status).toBe(301);
 				expect(response.headers.location).toEqual(relativePath);
+			});
+	});
+
+	test('intercepts an error from the backend', () => {
+		const scope = nock(backend).get('/interceptOn')
+			.reply(401, 'You are not authorised to view this content', {'content-type': 'text/plain'});
+
+		return request.get('/interceptOn')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({statusCode: 401});
 			});
 	});
 });

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -274,6 +274,19 @@ describe('Backend Proxy', () => {
 			}));
 		});
 
+		test('catches an error reading the backend stream', () => {
+			// Given
+			const middleware = backendProxy(baseOptions);
+			middleware(mockRequest, undefined, next);
+			proxyRequest.emit('response', backendResponse);
+
+			// When
+			backendResponse.emit('error', new Error('stream error'));
+
+			// Then
+			expect(next).toHaveBeenCalledWith(new Error('stream error'));
+		});
+
 		describe('when interceptErrors is on', () => {
 			let middleware;
 
@@ -312,8 +325,12 @@ describe('Backend Proxy', () => {
 				// Then
 				expect(backendResponse.pipe).not.toHaveBeenCalled();
 				expect(response.header).not.toHaveBeenCalledWith();
+				expect(response.statusCode).toBe(statusCode);
 				expect(next).toHaveBeenCalledTimes(1);
-				expect(next).toHaveBeenCalledWith({statusCode: statusCode});
+				expect(next).toHaveBeenCalledWith({
+					statusCode: statusCode,
+					backendResponse: backendResponse
+				});
 			});
 		});
 

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -9,7 +9,8 @@ const defaultOptions = {
 	key: 'backendResponse',
 	usePath: true,
 	requiredContentType: 'application/json',
-	changeHost: false
+	changeHost: false,
+	interceptErrors: false
 };
 
 /**
@@ -24,6 +25,7 @@ const defaultOptions = {
  * @param {boolean} [options.usePath=true] - Append the incoming HTTP request path to the backend URL
  * @param {string} [options.key=backendResponse] - The property name that the backend response is stored at
  * @param {boolean} [options.changeHost=false] - Should the request to the backend have its host field set to the backend url
+ * @param {boolean} [options.interceptErrors=false] - Should backend responses with HTTP 400 - 599 be intercepted and raised as express errors
  * @returns {function} - An Express middleware
  */
 function backendProxy(options) {
@@ -77,6 +79,10 @@ function backendProxy(options) {
 					}
 				});
 			} else {
+				if (options.interceptErrors && backendResponse.statusCode >= 400 && backendResponse.statusCode <= 599) {
+					return next({statusCode: backendResponse.statusCode});
+				}
+
 				// Pipe it back to the client as is
 				response.statusCode = backendResponse.statusCode;
 


### PR DESCRIPTION
Allows you to intercept errors from a backend (`400` -> `599`) and handle them with standard connect/express error handling