### PR TITLE
Simplify options

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 2.0.0
+_06/05/20_
+
+- Remove `changeHost` and `interceptErrors`. ([joeyciechanowicz](https://github.com/joeyciechanowicz))
+- Raise an error if the backend responds with `400 - 599`. ([joeyciechanowicz](https://github.com/joeyciechanowicz))
+
 ## 1.4.1
 _27/03/20_
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ The following table describe the properties of the `options` object.
 | `backend` | Backend service to proxy requests to | string |  |
 | `requiredContentType` | Backend response content type thats required to allow interception and deserialization | string | `application/json` |
 | `usePath` | Should the incoming HTTP request's path be apended to the `backend` URL | boolean | `true` |
-| `changeHost` | Set the `host` header on the backend HTTP request to the backend host | boolean | `false` |
-| `interceptErrors` | Should backend responses with HTTP 400 - 599 be intercepted and raised as express errors. | boolean | `false` |
 | `key` | The property on the request object that the backend response will be stored under. | string | `backendResponse` |
 
 ### `renderBackendResponse(options)`

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -23,13 +23,6 @@ app.use('/usePathOn', backendProxy({
 	requiredContentType: 'application/x+json'
 }));
 
-app.use('/changeHostOn', backendProxy({
-	backend,
-	usePath: true,
-	requiredContentType: 'application/x+json',
-	changeHost: true
-}));
-
 app.get('/interceptOn', backendProxy({
 	backend,
 	requiredContentType: 'application/x+json',
@@ -85,7 +78,7 @@ describe('Backend proxy integration', () => {
 			});
 	});
 
-	test('proxies a request with a changed host', () => {
+	test('changes host when proxying', () => {
 		const backendData = {
 			hello: 'world 3'
 		};
@@ -100,7 +93,7 @@ describe('Backend proxy integration', () => {
 		}).get('/abc/123')
 			.reply(200, backendData, {'Content-Type': 'application/x+json'});
 
-		return request.get('/changeHostOn/abc/123')
+		return request.get('/usePathOn/abc/123')
 			.then(response => {
 				scope.done();
 

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -23,12 +23,6 @@ app.use('/usePathOn', backendProxy({
 	requiredContentType: 'application/x+json'
 }));
 
-app.get('/interceptOn', backendProxy({
-	backend,
-	requiredContentType: 'application/x+json',
-	interceptErrors: true
-}));
-
 // Always return the backendResponse field as json
 app.use('*', (request, response) => {
 	response.json(request.backendResponse);
@@ -145,10 +139,10 @@ describe('Backend proxy integration', () => {
 	});
 
 	test('intercepts an error from the backend', () => {
-		const scope = nock(backend).get('/interceptOn')
+		const scope = nock(backend).get('/error')
 			.reply(401, 'You are not authorised to view this content', {'content-type': 'text/plain'});
 
-		return request.get('/interceptOn')
+		return request.get('/usePathOn/error')
 			.then(response => {
 				scope.done();
 

--- a/__tests__/unit/backend-proxy.test.js
+++ b/__tests__/unit/backend-proxy.test.js
@@ -77,6 +77,10 @@ describe('Backend Proxy', () => {
 		mockRequest.pipe.mockReturnValueOnce({
 			on: jest.fn()
 		});
+		mockRequest.headers = {
+			...mockRequest.headers,
+			host: 'original.host:8080'
+		};
 
 		// When
 		middleware(mockRequest, undefined, next);
@@ -88,7 +92,11 @@ describe('Backend Proxy', () => {
 			hostname: 'backend.local',
 			path: mockRequest.url,
 			method: mockRequest.method,
-			headers: mockRequest.headers
+			headers: {
+				...mockRequest.headers,
+				host: 'backend.local',
+				'X-Orig-Host': 'original.host:8080'
+			}
 		}));
 		// We haven't simulated an error or a response so next should not have been called at this point
 		expect(next).not.toHaveBeenCalled();
@@ -114,36 +122,6 @@ describe('Backend Proxy', () => {
 			path: '/sub/path',
 			method: mockRequest.method,
 			headers: mockRequest.headers
-		}));
-		// We haven't simulated an error or a response so next should not have been called at this point
-		expect(next).not.toHaveBeenCalled();
-	});
-
-	test(`pipes the request to the backend with the host header changed when changeHost is true`, () => {
-		// Given
-		const middleware = backendProxy({
-			...baseOptions,
-			usePath: false,
-			backend: 'http://backend.local/sub/path',
-			changeHost: true
-		});
-		mockRequest.headers = {
-			host: 'original.host:8080'
-		};
-
-		// When
-		middleware(mockRequest, undefined, next);
-
-		// Then
-		expect(request).toHaveBeenCalledWith(expect.objectContaining({
-			hostname: 'backend.local',
-			path: '/sub/path',
-			method: mockRequest.method,
-			headers: {
-				...mockRequest.headers,
-				host: 'backend.local',
-				'X-Orig-Host': 'original.host:8080'
-			}
 		}));
 		// We haven't simulated an error or a response so next should not have been called at this point
 		expect(next).not.toHaveBeenCalled();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/backend-proxy",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/backend-proxy",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Proxies frontend requests to a backend and can render the result",
   "main": "index.js",
   "files": [

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -9,7 +9,6 @@ const defaultOptions = {
 	key: 'backendResponse',
 	usePath: true,
 	requiredContentType: 'application/json',
-	changeHost: false,
 	interceptErrors: false
 };
 
@@ -89,7 +88,6 @@ function createHandler({request, response, next, options, backendHttpOptions}) {
  * @param {string} [options.requiredContentType=application/json] - The backend response content type to store for rendering, defaults to "application/json"
  * @param {boolean} [options.usePath=true] - Append the incoming HTTP request path to the backend URL
  * @param {string} [options.key=backendResponse] - The property name that the backend response is stored at
- * @param {boolean} [options.changeHost=false] - Should the request to the backend have its host field set to the backend url
  * @param {boolean} [options.interceptErrors=false] - Should backend responses with HTTP 400 - 599 be intercepted and raised as express errors
  * @returns {function} - An Express middleware
  */
@@ -119,10 +117,8 @@ function backendProxy(options) {
 			path: options.usePath ? basePath + request.url : backendHttpOptions.pathname
 		};
 
-		if (options.changeHost) {
-			request.headers['X-Orig-Host'] = request.headers.host;
-			request.headers.host = backendHttpOptions.host;
-		}
+		request.headers['X-Orig-Host'] = request.headers.host;
+		request.headers.host = backendHttpOptions.host;
 
 		// Pipe the incoming request through to the backend
 		const proxiedRequest = request.pipe(http.request(requestOptions));


### PR DESCRIPTION
Removes `interceptErrors` as an option as this is a sane default and otherwise requires a frontend to have logic for handling different status codes from a backend.

Removes `changeHost` as this is standard behavior and changing the host and storing the original in `X-Forwarded-Host` is a de-facto standard now.

The major and breaking change is to raise an error if the backend returns a `400 - 599` HTTP status code, without reading the backend response. It _might_ be useful for some teams to have the BE response read in the error states as well, but that can be added in when needed.
The need to do this is otherwise the proxy can intercept a response with code `500` but with a valid `content-type` and then pass data to the frontend application, without the application being aware there is any error.