### PR TITLE
Increases the lower limit of raising an express error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save @springernature/backend-proxy
 
 ### `backendProxy(options)`
 
-The `backend-proxy` middleware will take all incoming HTTP requests and forward them to a backend service. The backend response will then be stored on the original HTTP request to be used by your application, or automatically rendered using `render-backend-response`.
+The `backend-proxy` middleware will take all incoming HTTP requests and forward them to a backend service. The backend response will then be stored on the original HTTP request to be used by your application, or automatically rendered using `render-backend-response`. The status code from the backend will also be returned, this includes client errors (40X). However, server errors (50X) will result in an error being raised. 
 
 ```js
 const {backendProxy} = require('@springernature/backend-proxy');

--- a/__tests__/integration/backend-proxy.test.js
+++ b/__tests__/integration/backend-proxy.test.js
@@ -138,7 +138,7 @@ describe('Backend proxy integration', () => {
 			});
 	});
 
-	test('intercepts an error from the backend', () => {
+	test('proxies a client error from the backend', () => {
 		const scope = nock(backend).get('/error')
 			.reply(401, 'You are not authorised to view this content', {'content-type': 'text/plain'});
 
@@ -147,7 +147,20 @@ describe('Backend proxy integration', () => {
 				scope.done();
 
 				expect(response.status).toBe(401);
-				expect(response.text).toEqual(`Error 401`);
+				expect(response.text).toEqual('You are not authorised to view this content');
+			});
+	});
+
+	test('intercepts an error from the backend', () => {
+		const scope = nock(backend).get('/error')
+			.reply(501, 'Something went wrong', {'content-type': 'text/plain'});
+
+		return request.get('/usePathOn/error')
+			.then(response => {
+				scope.done();
+
+				expect(response.status).toBe(501);
+				expect(response.text).toEqual(`Error 501`);
 			});
 	});
 });

--- a/src/backend-proxy.js
+++ b/src/backend-proxy.js
@@ -51,7 +51,7 @@ function createHandler({request, response, next, options, backendHttpOptions}) {
 		response.statusCode = backendResponse.statusCode;
 
 		// Should we intercept the error and raise it as an express error
-		if (backendResponse.statusCode >= 400 && backendResponse.statusCode <= 599) {
+		if (backendResponse.statusCode >= 500 && backendResponse.statusCode <= 599) {
 			return next({statusCode: backendResponse.statusCode});
 		}
 


### PR DESCRIPTION
This PR increases the lower limit of raising an express error from a `statusCode` of `400`, to one of `500`. This means that all `40X`(client errors) will be handled on the frontend server, whilst all server errors will continue to be raised as express errors. 